### PR TITLE
Add support for GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Check DCO
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        python3 dco_check.py --verbose

--- a/event.json
+++ b/event.json
@@ -1,0 +1,3 @@
+{"pull_request": {"base": {"sha": "8636a4fb8b17e00fc29f0a00ba4a724f03a6430b"},
+                 "head": {"sha": "32d1a90a3bbbfb9250cb613b9b819530d2da8afe"}},
+"repository": {"compare_url": "https://api.github.com/repos/christophebedard/dco-check/compare/{base}...{head}"}}


### PR DESCRIPTION
Closes #9

Supersedes and closes #3 and closes #5

For GitHub, since the actual git repo that is checked out in CI only contains a partial history, we can just request commit data using the GitHub API.