### PR TITLE
Add --quiet option and improve printing

### DIFF
--- a/dco_check.py
+++ b/dco_check.py
@@ -38,7 +38,7 @@ TRAILER_KEY_SIGNED_OFF_BY = 'Signed-off-by:'
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description='Check that all commits of a proposed change have a DCO (i.e. are signed-off)',
+        description='Check that all commits of a proposed change have a DCO, i.e. are signed-off.',
     )
     parser.add_argument(
         '-v', '--verbose',

--- a/dco_check.py
+++ b/dco_check.py
@@ -41,16 +41,23 @@ def parse_args() -> argparse.Namespace:
         description='Check that all commits of a proposed change have a DCO, i.e. are signed-off.',
     )
     parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        help='verbose mode (print out more information)',
-    )
-    parser.add_argument(
         '-m', '--check-merge-commits',
         action='store_true',
         default=False,
         help='check sign-offs on merge commits as well',
+    )
+    output_options_group = parser.add_mutually_exclusive_group()
+    output_options_group.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        default=False,
+        help='quiet mode (do not print anything; simply exit with 0 or non-zero)',
+    )
+    output_options_group.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        help='verbose mode (print out more information)',
     )
     return parser.parse_args()
 
@@ -682,10 +689,11 @@ def check_infractions(
 
 
 def main() -> int:
-    args = parse_args()
     global verbose
-    verbose = args.verbose
+    args = parse_args()
     check_merge_commits = args.check_merge_commits
+    quiet = args.quiet
+    verbose = args.verbose
 
     # Detect CI
     # Use first one that applies

--- a/dco_check.py
+++ b/dco_check.py
@@ -686,7 +686,7 @@ def check_infractions(
     :return: 0 if no infractions, non-zero otherwise
     """
     if len(infractions) > 0:
-        logger.print('Missing sign-off(s)')
+        logger.print('Missing sign-off(s):')
         logger.print()
         for commit_sha, commit_infractions in infractions.items():
             logger.print('\t' + commit_sha)
@@ -721,8 +721,8 @@ def main() -> int:
     commit_hash_base, commit_hash_head = commit_range
 
     logger.print()
-    logger.verbose_print(f'checking commits: {commit_hash_base}..{commit_hash_head}')
-    logger.verbose_print()
+    logger.print(f'checking commits: {commit_hash_base}..{commit_hash_head}')
+    logger.print()
 
     # Get commits
     commits = commit_retriever.get_commits(commit_hash_base, commit_hash_head, check_merge_commits=check_merge_commits)


### PR DESCRIPTION
This adds a `-q|--quiet` option that prevents any `print()` call and simply lets the script exit with 0 or non-zero. The option is mutually exclusive with `-v|--verbose`. 

Closes #36