### PR TITLE
Add packaging files to release on PyPi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: python3 dco_check.py --verbose
+          command: python3 dco_check/dco_check.py --verbose
 
 workflows:
   workflow:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python3 dco_check.py --verbose
+        python3 dco_check/dco_check.py --verbose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,4 +8,4 @@ dco_check:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
     - if: $CI_COMMIT_BRANCH == 'master'
   script:
-    - python3 dco_check.py --verbose
+    - python3 dco_check/dco_check.py --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ python:
   - "3.8"
 dist: bionic
 script:
-  - python3 dco_check.py --verbose
+  - python3 dco_check/dco_check.py --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,4 +12,4 @@ environment:
 
 build: off
 test_script:
-  - "%PYTHON%\\python.exe dco_check.py --verbose"
+  - "%PYTHON%\\python.exe dco_check\\dco_check.py --verbose"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       versionSpec: '$(python.version)'
     displayName: 'Use Python $(python.version)'
   - script: |
-      python dco_check.py --verbose
+      python dco_check/dco_check.py --verbose
     displayName: 'Check DCO'
 - job: Windows
   pool:
@@ -38,5 +38,5 @@ jobs:
       versionSpec: '$(python.version)'
     displayName: 'Use Python $(python.version)'
   - script: |
-      python dco_check.py --verbose
+      python dco_check/dco_check.py --verbose
     displayName: 'Check DCO'

--- a/dco_check/__init__.py
+++ b/dco_check/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Christophe Bedard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .dco_check import __version__ as version
+
+
+__version__ = version

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -31,6 +31,9 @@ from typing import Tuple
 from typing import Union
 
 
+__version__ = '0.0.2'
+
+
 DEFAULT_BRANCH = 'master'
 DEFAULT_REMOTE = 'origin'
 TRAILER_KEY_SIGNED_OFF_BY = 'Signed-off-by:'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,53 @@
+[metadata]
+name = dco-check
+version = attr: dco_check.__version__
+url = https://github.com/christophebedard/dco-check/
+project_urls =
+    Changelog = https://github.com/christophebedard/dco-check/milestones?state=closed
+    GitHub = https://github.com/christophebedard/dco-check/
+author = Christophe Bedard
+author_email = bedard.christophe@gmail.com
+maintainer = Christophe Bedard
+maintainer_email = bedard.christophe@gmail.com
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: POSIX
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Software Development :: Testing
+license = Apache License, Version 2.0
+description = Simple DCO check script to be used in any CI.
+long_description = file: README.md
+keywords = dco, check
+
+[options]
+packages = find:
+tests_require =
+    flake8
+    flake8-blind-except
+    flake8-builtins
+    flake8-class-newline
+    flake8-comprehensions
+    flake8-deprecated
+    flake8-docstrings
+    flake8-import-order
+    flake8-quotes
+    pep8-naming
+    pyenchant
+    pylint
+    pytest
+    pytest-cov
+zip_safe = true
+
+[options.entry_points]
+console_scripts =
+    dco-check = dco_check.dco_check:main
+
+[flake8]
+import-order-style = google
+max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Christophe Bedard
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools
+
+setuptools.setup()

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,4 @@
+[dco-check]
+Depends3: python3
+Suite: xenial bionic focal stretch buster
+X-Python3-Version: >= 3.6


### PR DESCRIPTION
This adds the necessary setup files. I moved the main `dco_check.py` file to a `dco_check/` directory, but it's still possible to use it by itself, e.g. `python3 dco_check/dco_check.py`

https://pypi.org/project/dco-check/

Current version: `0.0.2`

Closes #42