### PR TITLE
Add GitHub CI job to package and upload to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
+    - name: Check release tag vs dco_check.__version__
+      run: |
+        python3 -c "import dco_check; assert dco_check.__version__ == '${GITHUB_REF/refs\/tags\//}', 'git tag and dco_check version do not match'"
     - name: Generate package
       run: |
         python3 -m pip install --user --upgrade setuptools wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Package
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Generate package
+      run: |
+        python3 -m pip install --user --upgrade setuptools wheel
+        python3 setup.py sdist bdist_wheel
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Status](https://img.shields.io/github/workflow/status/christophebedard/dco-check
 [![Azure DevOps builds](https://img.shields.io/azure-devops/build/christophebedard/74e64a5d-0fe6-4759-bb97-eb77bb0d15af/1?label=CI&logo=azure%20pipelines)](https://dev.azure.com/christophebedard/dco-check/_build/latest?definitionId=1&branchName=master)
 [![AppVeyor](https://img.shields.io/appveyor/build/christophebedard/dco-check?label=CI&logo=appveyor)](https://ci.appveyor.com/project/christophebedard/dco-check)
 [![CircleCI](https://img.shields.io/circleci/build/github/christophebedard/dco-check?label=CI&logo=circle&logoColor=white)](https://circleci.com/gh/christophebedard/dco-check)
+[![PyPI](https://img.shields.io/pypi/v/dco-check)](https://pypi.org/project/dco-check/)
 [![License](https://img.shields.io/github/license/christophebedard/dco-check)](https://github.com/christophebedard/dco-check/blob/master/LICENSE)
 
 Simple DCO check script to be used in any CI.


### PR DESCRIPTION
This adds a GitHub workflow that only runs when tags matching `'[0-9]+.[0-9]+.[0-9]+'` are pushed. It first checks that the tag matches `dco_check.__version__`, and then it generates the package and uploads it to PyPI.

Closes #48