### PR TITLE
Set long_description_content_type to text/markdown for README

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
 license = Apache License, Version 2.0
 description = Simple DCO check script to be used in any CI.
 long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = dco, check
 
 [options]

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,5 @@
 
 import setuptools
 
+
 setuptools.setup()


### PR DESCRIPTION
Closes #51

Using `long_description_content_type = text/markdown` should do the trick assuming the `package` job uses recent versions of `setuptools`/`wheel`

See: https://github.com/pypa/warehouse/issues/3664