### PR TITLE
Add more information to README and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,71 @@ Status](https://img.shields.io/github/workflow/status/christophebedard/dco-check
 [![License](https://img.shields.io/github/license/christophebedard/dco-check)](https://github.com/christophebedard/dco-check/blob/master/LICENSE)
 
 Simple DCO check script to be used in any CI.
+
+## Motivation
+
+Many open-source projects require the use of a `Signed-off-by:` line in every commit message.
+This is to certify that a contributor has the right to submit their code according to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+However, to my knowledge, there is no automated check that can run on any CI platform (or most platforms).
+Some platforms simply do not possess such a feature.
+
+This was inspired by the [DCO GitHub App](https://github.com/apps/dco).
+
+## How to get & use
+
+There are two main options:
+
+1. Using the [package from PyPI](https://pypi.org/project/dco-check/)
+    ```shell
+    $ pip install dco-check
+    $ dco-check
+    ```
+1. Downloading the script and running it (you can replace `master` with a specific version)
+    ```shell
+    $ wget https://raw.githubusercontent.com/christophebedard/dco-check/master/dco_check/dco_check.py
+    $ python3 dco_check.py
+    ```
+
+It exits with 0 if all checked commits have been signed-off.
+Otherwise, it exits with a non-zero number.
+
+Run with `--help` for more information and options, including:
+
+* ignoring merge commits
+* default branch
+* default remote
+* quiet mode
+* verbose mode
+
+Those options can alternatively be set through environment variables (see `--help`).
+
+## How it works
+
+`dco-check` focuses on two use-cases:
+
+1. Commits part of a feature branch, i.e. a proposed change (pull request or merge request)
+1. Commits on the default branch, e.g. `master`, especially the new commits pushed to the default branch
+
+The first use-case is easy to cover given a normal git repository.
+We can simply use `git merge-base --fork-point $DEFAULT_BRANCH` to get the list of commits on a specific feature branch.
+Then we can just check every commit using `git log` and make sure it is signed-off by the author.
+
+The second use-case isn't really possible, because a git repository does not contain the necessary information (AFAIK).
+Fortunately, some CIs do provide this information.
+
+Furthermore, by default, some CI platforms only clone git repositories up to a specific depth, i.e. you only get a partial commit history.
+This depth can sometimes be 1 for some CIs.
+For those cases, it is usually possible to prevent shallow cloning by setting the right parameter(s) in the job configuration.
+However, since one of the goals of `dco-check` is to be as easy to use as possible, it tries not to rely on that.
+
+This is why `dco-check` detects the current CI platform and uses whatever information that platform can provide.
+Otherwise, it falls back on a default generic implementation which uses simple git commands.
+
+<!-- ## CI support -->
+
+<!-- ## Example CI configurations -->
+
+## Python version support
+
+Python 3.6+ is required because of the use of f-strings.
+However, it shouldn't be too hard to remove them to support older versions of Python 3, if there is demand for it, or if such a change is contributed to `dco-check`.

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -35,6 +35,11 @@ __version__ = '0.0.4'
 
 DEFAULT_BRANCH = 'master'
 DEFAULT_REMOTE = 'origin'
+ENV_VAR_CHECK_MERGE_COMMITS = 'DCO_CHECK_CHECK_MERGE_COMMITS'
+ENV_VAR_DEFAULT_BRANCH = 'DCO_CHECK_DEFAULT_BRANCH'
+ENV_VAR_DEFAULT_REMOTE = 'DCO_CHECK_DEFAULT_REMOTE'
+ENV_VAR_QUIET = 'DCO_CHECK_QUIET'
+ENV_VAR_VERBOSE = 'DCO_CHECK_VERBOSE'
 TRAILER_KEY_SIGNED_OFF_BY = 'Signed-off-by:'
 
 
@@ -88,31 +93,46 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '-b', '--default-branch',
         default=wrap_default_value(DEFAULT_BRANCH),
-        help='default branch to use, if necessary (default: %(default)s)',
+        help=(
+            'default branch to use, if necessary (default: %(default)s) '
+            f'(environment variable: {ENV_VAR_DEFAULT_BRANCH})'
+        ),
     )
     parser.add_argument(
         '-m', '--check-merge-commits',
         action='store_true',
         default=wrap_default_value(False),
-        help='check sign-offs on merge commits as well',
+        help=(
+            'check sign-offs on merge commits as well '
+            f'(environment variable: {ENV_VAR_CHECK_MERGE_COMMITS})'
+        ),
     )
     parser.add_argument(
         '-r', '--default-remote',
         default=wrap_default_value(DEFAULT_REMOTE),
-        help='default remote to use, if necessary (default: %(default)s)',
+        help=(
+            'default remote to use, if necessary (default: %(default)s) '
+            f'(environment variable: {ENV_VAR_DEFAULT_REMOTE})'
+        ),
     )
     output_options_group = parser.add_mutually_exclusive_group()
     output_options_group.add_argument(
         '-q', '--quiet',
         action='store_true',
         default=wrap_default_value(False),
-        help='quiet mode (do not print anything; simply exit with 0 or non-zero)',
+        help=(
+            'quiet mode (do not print anything; simply exit with 0 or non-zero) '
+            f'(environment variable: {ENV_VAR_QUIET})'
+        ),
     )
     output_options_group.add_argument(
         '-v', '--verbose',
         action='store_true',
         default=wrap_default_value(False),
-        help='verbose mode (print out more information)',
+        help=(
+            'verbose mode (print out more information) '
+            f'(environment variable: {ENV_VAR_VERBOSE})'
+        ),
     )
     return parser
 
@@ -177,20 +197,20 @@ class Options:
         self.check_merge_commits = environment_value_if_default_param(
             'check_merge_commits',
             bool,
-            'DCO_CHECK_CHECK_MERGE_COMMITS',
+            ENV_VAR_CHECK_MERGE_COMMITS,
         )
         self.default_branch = environment_value_if_default_param(
             'default_branch',
             str,
-            'DCO_CHECK_DEFAULT_BRANCH',
+            ENV_VAR_DEFAULT_BRANCH,
         )
         self.default_remote = environment_value_if_default_param(
             'default_remote',
             str,
-            'DCO_CHECK_DEFAULT_REMOTE',
+            ENV_VAR_DEFAULT_REMOTE,
         )
-        self.quiet = environment_value_if_default_param('quiet', bool, 'DCO_CHECK_QUIET')
-        self.verbose = environment_value_if_default_param('verbose', bool, 'DCO_CHECK_VERBOSE')
+        self.quiet = environment_value_if_default_param('quiet', bool, ENV_VAR_QUIET)
+        self.verbose = environment_value_if_default_param('verbose', bool, ENV_VAR_VERBOSE)
         if self.quiet and self.verbose:
             raise ValueError("'quiet' and 'verbose' cannot both be true")
 


### PR DESCRIPTION
This adds a few sections to the README to explain the motivation behind `dco-check`, how it can be used, and how it works.

Closes #16