### PR TITLE
Use GitHub action to automatically tag version commits

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,14 @@
+name: 'tag'
+on:
+  push:
+    branches:
+      - master
+      - 'releases/*'
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: christophebedard/tag-version-commit@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/christophebedard/tag-version-commit

Therefore, pushing version commit should create a tag, which in turn should package and release to PyPI.

Closes #60