### PR TITLE
Improve CI behaviours

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
         type: string
     docker:
       - image: python:<< parameters.python_version >>
+    environment:
+      CIRCLE_BASE_REVISION: << pipeline.git.base_revision >>
     steps:
       - checkout
       - run:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Below is a summary of the supported CIs along with their known behaviour.
 |:--:|:--------------------------------------------------:|:----------------------:|:-----:|
 |GitHub|✓|CI|retrieves commit data using the GitHub API, since GitHub does shallow clones by default|
 |GitLab|✓|CI|detects normal GitLab MRs and external (GitHub) MRs|
-|Azure Pipelines||CLI arguments||
-|AppVeyor|✓|CLI arguments||
+|Azure Pipelines||CI||
+|AppVeyor||CI||
 |CircleCI|?|CLI arguments|can use base revision information if provided (see example)|
 |Travis CI||CLI arguments|supported by default as a normal git repo|
 |default (git)||CLI arguments|use locally; using in an unsupported CI which only does a shallow clone might cause problems|

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Below is a summary of the supported CIs along with their known behaviour.
 
 | CI | Detects new changes when pushing to default branch | Gets base branch using | Notes |
 |:--:|:--------------------------------------------------:|:----------------------:|:-----:|
-|GitHub|✓|(not used)|retrieves commit data using the GitHub API|
+|GitHub|✓|CI|retrieves commit data using the GitHub API, since GitHub does shallow clones by default|
 |GitLab|✓|CI|detects normal GitLab MRs and external (GitHub) MRs|
 |Azure Pipelines||CLI arguments||
 |AppVeyor|✓|CLI arguments||

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Below is a summary of the supported CIs along with their known behaviour.
 | CI | Detects new changes when pushing to default branch | Gets base branch using | Notes |
 |:--:|:--------------------------------------------------:|:----------------------:|:-----:|
 |GitHub|✓|(not used)|retrieves commit data using the GitHub API|
-|GitLab|✓|CI||
+|GitLab|✓|CI|detects normal GitLab MRs and external (GitHub) MRs|
 |Azure Pipelines||CLI arguments||
 |AppVeyor|✓|CLI arguments||
 |CircleCI|?|CLI arguments|can use base revision information if provided (see example)|

--- a/README.md
+++ b/README.md
@@ -72,7 +72,18 @@ However, since one of the goals of `dco-check` is to be as easy to use as possib
 This is why `dco-check` detects the current CI platform and uses whatever information that platform can provide.
 Otherwise, it falls back on a default generic implementation which uses simple git commands.
 
-<!-- ## CI support -->
+## CI support
+
+Below is a summary of the supported CIs along with their known behaviour.
+
+| CI | Default branch detection | New changes on default branch |
+|:--:|:--------------------------------------:|:-----------------------------:|
+|GitHub|yes, using command||
+|GitLab|yes, through CI|yes|
+|Azure Pipelines|yes, using command||
+|AppVeyor|yes, using command||
+|CircleCI|yes, using command||
+|Git (default)|yes, using command|no|
 
 <!-- ## Example CI configurations -->
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Otherwise, it falls back on a default generic implementation which uses simple g
 
 Below is a summary of the supported CIs along with their known behaviour.
 
-| CI | Detects new changes when pushing to default branch | Gets base branch using | Notes |
-|:--:|:--------------------------------------------------:|:----------------------:|:-----:|
-|GitHub|✓|CI|retrieves commit data using the GitHub API, since GitHub does shallow clones by default|
-|GitLab|✓|CI|detects normal GitLab MRs and external (GitHub) MRs|
-|Azure Pipelines||CI||
-|AppVeyor||CI||
-|CircleCI|?|CLI arguments|can use base revision information if provided (see example)|
-|Travis CI||CLI arguments|supported by default as a normal git repo|
-|default (git)||CLI arguments|use locally; using in an unsupported CI which only does a shallow clone might cause problems|
+| CI | Detects new changes when pushing to default branch | Detects PRs/MRs | Gets base branch using | Get default branch using | Notes |
+|:--:|:--------------------------------------------------:|:---------------:|:----------------------:|:------------------------:|:-----:|
+|GitHub|✓|✓|CI|(not used)|retrieves commit data using the GitHub API, since GitHub does shallow clones by default|
+|GitLab|✓|✓|CI|CI|detects normal GitLab MRs and external (GitHub) MRs|
+|Azure Pipelines||✓|CI|CLI arguments||
+|AppVeyor||✓|CI|CLI arguments||
+|CircleCI|?||CI\* (or CLI arguments)|CLI arguments|\*can use base revision information if provided (see example)|
+|Travis CI|||CLI arguments|CLI arguments|supported by default as a normal git repo|
+|default (git)|||CLI arguments|CLI arguments|use locally; using in an unsupported CI which only does a shallow clone might cause problems|
 
 <!-- ## Example CI configurations -->
 

--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ Otherwise, it falls back on a default generic implementation which uses simple g
 
 Below is a summary of the supported CIs along with their known behaviour.
 
-| CI | Default branch detection | New changes on default branch |
-|:--:|:--------------------------------------:|:-----------------------------:|
-|GitHub|yes, using command||
-|GitLab|yes, through CI|yes|
-|Azure Pipelines|yes, using command||
-|AppVeyor|yes, using command||
-|CircleCI|yes, using command||
-|Git (default)|yes, using command|no|
+| CI | Detects new changes when pushing to default branch | Gets base branch using | Notes |
+|:--:|:--------------------------------------------------:|:----------------------:|:-----:|
+|GitHub|✓|(not used)|retrieves commit data using the GitHub API|
+|GitLab|✓|CI||
+|Azure Pipelines||CLI arguments||
+|AppVeyor|✓|CLI arguments||
+|CircleCI|?|CLI arguments|can use base revision information if provided (see example)|
+|Travis CI||CLI arguments|supported by default as a normal git repo|
+|default (git)||CLI arguments|use locally; using in an unsupported CI which only does a shallow clone might cause problems|
 
 <!-- ## Example CI configurations -->
 

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -656,7 +656,8 @@ class CircleCiRetriever(CommitDataRetriever):
         if commit_hash_head is None:
             return None
 
-        # TODO support testing only new commits on the default branch
+        # TODO support testing only new commits on the default branch using pipeline variables
+        #   https://circleci.com/docs/2.0/pipeline-variables/
         current_branch = get_env_var('CIRCLE_BRANCH')
         if current_branch is None:
             return None

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -658,6 +658,8 @@ class CircleCiRetriever(CommitDataRetriever):
 
         # TODO support testing only new commits on the default branch
         current_branch = get_env_var('CIRCLE_BRANCH')
+        if current_branch is None:
+            return None
 
         # Test all commits off of the default branch
         logger.verbose_print(
@@ -710,6 +712,8 @@ class AzurePipelinesRetriever(CommitDataRetriever):
 
         # TODO support testing only new commits on the default branch
         current_branch = get_env_var('BUILD_SOURCEBRANCHNAME')
+        if current_branch is None:
+            return None
 
         # TODO use 'System.PullRequest.TargetBranch' and 'System.PullRequest.PullRequestId'
 

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -600,6 +600,19 @@ class GitlabRetriever(GitRetriever):
             if target_branch_sha is None:
                 return None
             return target_branch_sha, commit_hash_head
+        elif get_env_var('CI_EXTERNAL_PULL_REQUEST_IID', print_if_not_found=False):
+            # Get external merge request target branch
+            target_branch = get_env_var('CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME')
+            if target_branch is None:
+                return None
+            logger.verbose_print(
+                f"\ton merge request branch '{current_branch}': "
+                f"will check new commits off of target branch '{target_branch}'"
+            )
+            target_branch_sha = get_env_var('CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA')
+            if target_branch_sha is None:
+                return None
+            return target_branch_sha, commit_hash_head
         else:
             # Otherwise test all commits off of the default branch
             logger.verbose_print(

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -644,7 +644,6 @@ class CircleCiRetriever(GitRetriever):
         #   https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
         base_revision = get_env_var('CIRCLE_BASE_REVISION', print_if_not_found=False)
         if base_revision:
-            # TODO: check if this allows us to check new commits pushed to master
             logger.verbose_print(
                 f"\tchecking commits off of base revision '{base_revision}'"
             )

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -304,32 +304,6 @@ def get_common_ancestor_commit_hash(
     return run(command)
 
 
-def get_default_branch_from_remote(
-    remote: str,
-) -> Optional[str]:
-    """
-    Get default branch from remote.
-
-    :param remote: the remote name
-    :return: the default branch, or None if it failed
-    """
-    # https://stackoverflow.com/questions/28666357/git-how-to-get-default-branch#comment92366240_50056710  # noqa: E501
-    #   $ git remote show origin
-    cmd = ['git', 'remote', 'show', remote]
-    result = run(cmd)
-    if not result:
-        return None
-    result_lines = result.split('\n')
-    branch = None
-    for result_line in result_lines:
-        # There is a two-space indentation
-        match = re.match('  HEAD branch: (.*)', result_line)
-        if match is not None:
-            branch = match[1]
-            break
-    return branch
-
-
 def fetch_branch(
     branch: str,
     remote: str = 'origin',

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -505,23 +505,14 @@ class CommitDataRetriever:
 class GitRetriever(CommitDataRetriever):
     """Implementation for any git repository."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'git (default)'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         # Unless we only have access to a partial commit history
         return True
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         default_branch = options.default_branch
         logger.verbose_print(f"\tusing default branch '{default_branch}'")
         commit_hash_base = get_common_ancestor_commit_hash(default_branch)
@@ -538,8 +529,7 @@ class GitRetriever(CommitDataRetriever):
         head: str,
         check_merge_commits: bool = False,
         **kwargs,
-    ) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         ignore_merge_commits = not check_merge_commits
         commits_data = get_commits_data(base, head, ignore_merge_commits=ignore_merge_commits)
         individual_commits = split_commits_data(commits_data)
@@ -572,22 +562,13 @@ class GitRetriever(CommitDataRetriever):
 class GitlabRetriever(CommitDataRetriever):
     """Implementation for GitLab CI."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'GitLab'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         return get_env_var('GITLAB_CI', print_if_not_found=False) is not None
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         # See: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         default_branch = get_env_var('CI_DEFAULT_BRANCH', default=options.default_branch)
 
@@ -624,30 +605,25 @@ class GitlabRetriever(CommitDataRetriever):
                 return None
             return commit_hash_base, commit_hash_head
 
-    def get_commits(self, base: str, head: str, **kwargs) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    def get_commits(
+        self,
+        base: str,
+        head: str,
+        **kwargs,
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         return GitRetriever().get_commits(base, head, **kwargs)
 
 
 class CircleCiRetriever(CommitDataRetriever):
     """Implementation for CircleCI."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'CircleCI'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         return get_env_var('CIRCLECI', print_if_not_found=False) is not None
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         # See: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
         default_branch = options.default_branch
         logger.verbose_print(f"\tusing default branch '{default_branch}'")
@@ -679,30 +655,25 @@ class CircleCiRetriever(CommitDataRetriever):
             return None
         return commit_hash_base, commit_hash_head
 
-    def get_commits(self, base: str, head: str, **kwargs) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    def get_commits(
+        self,
+        base: str,
+        head: str,
+        **kwargs,
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         return GitRetriever().get_commits(base, head, **kwargs)
 
 
 class AzurePipelinesRetriever(CommitDataRetriever):
     """Implementation for Azure Pipelines."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'Azure Pipelines'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         return get_env_var('TF_BUILD', print_if_not_found=False) is not None
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables  # noqa: E501
         default_branch = options.default_branch
         logger.verbose_print(f"\tusing default branch '{default_branch}'")
@@ -758,30 +729,25 @@ class AzurePipelinesRetriever(CommitDataRetriever):
                 return None
             return commit_hash_base, commit_hash_head
 
-    def get_commits(self, base: str, head: str, **kwargs) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    def get_commits(
+        self,
+        base: str,
+        head: str,
+        **kwargs,
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         return GitRetriever().get_commits(base, head, **kwargs)
 
 
 class AppVeyorRetriever(CommitDataRetriever):
     """Implementation for AppVeyor."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'AppVeyor'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         return get_env_var('APPVEYOR', print_if_not_found=False) is not None
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         # See: https://www.appveyor.com/docs/environment-variables/
         default_branch = options.default_branch
         logger.verbose_print(f"\tusing default branch '{default_branch}'")
@@ -818,30 +784,25 @@ class AppVeyorRetriever(CommitDataRetriever):
                 return None
             return commit_hash_base, commit_hash_head
 
-    def get_commits(self, base: str, head: str, **kwargs) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    def get_commits(
+        self,
+        base: str,
+        head: str,
+        **kwargs,
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         return GitRetriever().get_commits(base, head, **kwargs)
 
 
 class GitHubRetriever(CommitDataRetriever):
     """Implementation for GitHub CI."""
 
-    def name(self) -> str:
-        """Get a name that represents this retriever."""
+    def name(self) -> str:  # noqa: D102
         return 'GitHub CI'
 
-    def applies(self) -> bool:
-        """Check if this retriever applies, i.e. can provide commit data."""
+    def applies(self) -> bool:  # noqa: D102
         return get_env_var('GITHUB_ACTIONS', print_if_not_found=False) == 'true'
 
-    def get_commit_range(self) -> Optional[Tuple[str, str]]:
-        """
-        Get the range of commits to be checked: (last commit that was checked, latest commit).
-
-        The range excludes the first commit, e.g. ]first commit, second commit]
-
-        :return the (last commit that was checked, latest commit) tuple, or `None` if it failed
-        """
+    def get_commit_range(self) -> Optional[Tuple[str, str]]:  # noqa: D102
         # See: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
         self.github_token = get_env_var('GITHUB_TOKEN')
         if self.github_token is None:
@@ -892,8 +853,12 @@ class GitHubRetriever(CommitDataRetriever):
             return None
         return commit_hash_base, commit_hash_head
 
-    def get_commits(self, base: str, head: str, **kwargs) -> Optional[List[CommitInfo]]:
-        """Get commit data."""
+    def get_commits(
+        self,
+        base: str,
+        head: str,
+        **kwargs,
+    ) -> Optional[List[CommitInfo]]:  # noqa: D102
         # Request commit data
         compare_url_template = self.event_payload['repository']['compare_url']
         compare_url = compare_url_template.format(base=base, head=head)

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -587,6 +587,19 @@ class GitlabRetriever(GitRetriever):
             if commit_hash_base is None:
                 return None
             return commit_hash_base, commit_hash_head
+        elif get_env_var('CI_MERGE_REQUEST_ID', print_if_not_found=False):
+            # Get merge request target branch
+            target_branch = get_env_var('CI_MERGE_REQUEST_TARGET_BRANCH_NAME')
+            if target_branch is None:
+                return None
+            logger.verbose_print(
+                f"\ton merge request branch '{current_branch}': "
+                f"will check new commits off of target branch '{target_branch}'"
+            )
+            target_branch_sha = get_env_var('CI_MERGE_REQUEST_TARGET_BRANCH_SHA')
+            if target_branch_sha is None:
+                return None
+            return target_branch_sha, commit_hash_head
         else:
             # Otherwise test all commits off of the default branch
             logger.verbose_print(
@@ -693,7 +706,6 @@ class AzurePipelinesRetriever(GitRetriever):
             )
             base_branch = target_branch
         else:
-            # TODO support testing only new commits on the default branch
             # Test all commits off of the default branch
             default_branch = options.default_branch
             logger.verbose_print(

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -559,7 +559,7 @@ class GitRetriever(CommitDataRetriever):
         return commits
 
 
-class GitlabRetriever(CommitDataRetriever):
+class GitlabRetriever(GitRetriever):
     """Implementation for GitLab CI."""
 
     def name(self) -> str:  # noqa: D102
@@ -605,16 +605,8 @@ class GitlabRetriever(CommitDataRetriever):
                 return None
             return commit_hash_base, commit_hash_head
 
-    def get_commits(
-        self,
-        base: str,
-        head: str,
-        **kwargs,
-    ) -> Optional[List[CommitInfo]]:  # noqa: D102
-        return GitRetriever().get_commits(base, head, **kwargs)
 
-
-class CircleCiRetriever(CommitDataRetriever):
+class CircleCiRetriever(GitRetriever):
     """Implementation for CircleCI."""
 
     def name(self) -> str:  # noqa: D102
@@ -655,16 +647,8 @@ class CircleCiRetriever(CommitDataRetriever):
             return None
         return commit_hash_base, commit_hash_head
 
-    def get_commits(
-        self,
-        base: str,
-        head: str,
-        **kwargs,
-    ) -> Optional[List[CommitInfo]]:  # noqa: D102
-        return GitRetriever().get_commits(base, head, **kwargs)
 
-
-class AzurePipelinesRetriever(CommitDataRetriever):
+class AzurePipelinesRetriever(GitRetriever):
     """Implementation for Azure Pipelines."""
 
     def name(self) -> str:  # noqa: D102
@@ -729,16 +713,8 @@ class AzurePipelinesRetriever(CommitDataRetriever):
                 return None
             return commit_hash_base, commit_hash_head
 
-    def get_commits(
-        self,
-        base: str,
-        head: str,
-        **kwargs,
-    ) -> Optional[List[CommitInfo]]:  # noqa: D102
-        return GitRetriever().get_commits(base, head, **kwargs)
 
-
-class AppVeyorRetriever(CommitDataRetriever):
+class AppVeyorRetriever(GitRetriever):
     """Implementation for AppVeyor."""
 
     def name(self) -> str:  # noqa: D102
@@ -783,14 +759,6 @@ class AppVeyorRetriever(CommitDataRetriever):
             if commit_hash_base is None:
                 return None
             return commit_hash_base, commit_hash_head
-
-    def get_commits(
-        self,
-        base: str,
-        head: str,
-        **kwargs,
-    ) -> Optional[List[CommitInfo]]:  # noqa: D102
-        return GitRetriever().get_commits(base, head, **kwargs)
 
 
 class GitHubRetriever(CommitDataRetriever):

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -736,14 +736,14 @@ class AppVeyorRetriever(GitRetriever):
         if branch is None:
             return None
 
-        # Check if merge request
+        # Check if pull request
         if get_env_var('APPVEYOR_PULL_REQUEST_NUMBER', print_if_not_found=False):
             current_branch = get_env_var('APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH')
             if current_branch is None:
                 return None
             target_branch = branch
             logger.verbose_print(
-                f"\ton merge request branch '{current_branch}': "
+                f"\ton pull request branch '{current_branch}': "
                 f"will check commits off of target branch '{target_branch}'"
             )
             commit_hash_head = get_env_var('APPVEYOR_PULL_REQUEST_HEAD_COMMIT') or commit_hash_head


### PR DESCRIPTION
This does a number of improvements:

* Detect normal GitLab MRs and external (GitHub) MRs
* Use base revision for CircleCI if provided (through the CI config)
* Detect PRs and base branch for Azure Pipelines
* Detect PRs and base branch for AppVeyor

And:

* Add "CI support" table to README describing each CI's behaviour and quirks
* Cleanup classes, remove unnecessary duplication

Closes #39