### PR TITLE
Make codecov result informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      threshold:
+        threshold: 0%


### PR DESCRIPTION
So it doesn't fail jobs.

Closes #67