### PR TITLE
Generate and upload coverage information for other CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,13 @@ jobs:
             pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint
       - run:
           name: Run tests
-          command: python -m pytest
+          command: python -m pytest --cov=dco_check --cov-branch --cov-report=xml
+      - codecov/upload
       - run:
           name: Check DCO
           command: python3 dco_check/dco_check.py --verbose
-
+orbs:
+  codecov: codecov/codecov@1.1.0
 workflows:
   workflow:
     jobs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,10 @@ Test:
   before_script:
     - pip install -U pytest pytest-cov pytest-repeat
     - pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint
+    - pip install -U codecov
   script:
-    - python3 -m pytest
+    - python3 -m pytest --cov=dco_check --cov-branch --cov-report=xml
+    - codecov -t $CODECOV_TOKEN
 
 Check DCO:
   image: python:3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ dist: bionic
 install:
   - pip install -U pytest pytest-cov pytest-repeat
   - pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint
+  - pip install -U codecov
 script:
-  - python3 -m pytest
+  - python3 -m pytest --cov=dco_check --cov-branch --cov-report=xml
+  - codecov
   - python3 dco_check/dco_check.py --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,9 @@ environment:
 install:
   - "%PYTHON%\\python.exe -m pip install -U pytest pytest-cov pytest-repeat"
   - "%PYTHON%\\python.exe -m pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint"
+  - "%PYTHON%\\python.exe -m pip install -U codecov"
 build: off
 test_script:
-  - "%PYTHON%\\python.exe -m pytest"
+  - "%PYTHON%\\python.exe -m pytest --cov=dco_check --cov-branch --cov-report=xml"
   - "%PYTHON%\\python.exe dco_check\\dco_check.py --verbose"
+  - "%PYTHON%\\python.exe -m codecov -f coverage.xml"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 trigger:
 - master
-
 jobs:
 - job: Linux
   pool:
@@ -21,10 +20,16 @@ jobs:
   - script: |
       pip install -U pytest pytest-cov pytest-repeat
       pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint
+      pip install -U codecov
     displayName: 'Install test dependencies'
   - script: |
-      python -m pytest
+      python -m pytest --cov=dco_check --cov-branch --cov-report=xml
     displayName: 'Run tests'
+  - script: |
+      codecov
+    displayName: 'Upload coverage'
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
   - script: |
       python dco_check/dco_check.py --verbose
     displayName: 'Check DCO'
@@ -47,10 +52,16 @@ jobs:
   - script: |
       pip install -U pytest pytest-cov pytest-repeat
       pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint
+      pip install -U codecov
     displayName: 'Install test dependencies'
   - script: |
-      python -m pytest
+      python -m pytest --cov=dco_check --cov-branch --cov-report=xml
     displayName: 'Run tests'
+  - script: |
+      codecov
+    displayName: 'Upload coverage'
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
   - script: |
       python dco_check/dco_check.py --verbose
     displayName: 'Check DCO'

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -823,7 +823,7 @@ class GitHubRetriever(CommitDataRetriever):
             else:
                 commit_hash_base = self.event_payload['before']
             commit_hash_head = self.event_payload['head_commit']['id']
-        else:
+        else:  # pragma: no cover
             logger.print('Unknown workflow event:', event_name)
             return None
         return commit_hash_base, commit_hash_head
@@ -844,7 +844,7 @@ class GitHubRetriever(CommitDataRetriever):
         }
         connection.request('GET', compare_url, headers=headers)
         response = connection.getresponse()
-        if 200 != response.getcode():
+        if 200 != response.getcode():  # pragma: no cover
             from pprint import pprint
             logger.print('Request failed: compare_url')
             logger.print('reponse:', pprint(response.read().decode()))


### PR DESCRIPTION
Only the GitHub Workflow config was generating coverage information and uploading it. Doing that with the other CIs should boost the coverage.

Relates to #58