### PR TITLE
Allow getting default branch from remote

### DIFF
--- a/test/test_dco_check.py
+++ b/test/test_dco_check.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+from dco_check.dco_check import get_default_branch_from_remote
 from dco_check.dco_check import main
 
 
@@ -26,3 +27,7 @@ class TestDcoCheck(unittest.TestCase):
 
     def test_main(self) -> None:
         self.assertEqual(0, main(['-v']))
+
+    def test_get_default_branch_from_remote(self) -> None:
+        remote_default_branch = get_default_branch_from_remote('origin')
+        self.assertEqual('master', remote_default_branch)

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -33,6 +33,7 @@ class TestLogger(unittest.TestCase):
         ns = argparse.Namespace(
             check_merge_commits=False,
             default_branch='b',
+            default_branch_from_remote=False,
             default_remote='c',
             quiet=False,
             verbose=False,
@@ -55,6 +56,7 @@ class TestLogger(unittest.TestCase):
         ns = argparse.Namespace(
             check_merge_commits=False,
             default_branch='b',
+            default_branch_from_remote=False,
             default_remote='c',
             quiet=False,
             verbose=True,
@@ -69,6 +71,7 @@ class TestLogger(unittest.TestCase):
         ns = argparse.Namespace(
             check_merge_commits=False,
             default_branch='b',
+            default_branch_from_remote=False,
             default_remote='c',
             quiet=True,
             verbose=False,


### PR DESCRIPTION
This allows users to ask `dco-check` to get the default branch from the remote. It uses a `git remote show $REMOTE` command to get the value. Of course, the remote name can be changed with the `--default-remote` option (or the equivalent env var).

This cannot be used alongside the `--default-branch` option or the equivalent env vars; they are mutually exclusive.