### PR TITLE
Don't check commits for scheduled GitLab pipelines

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -609,9 +609,13 @@ class GitlabRetriever(GitRetriever):
         if commit_hash_head is None:
             return None
 
-        # If we're on the default branch, just test new commits
         current_branch = get_env_var('CI_COMMIT_BRANCH')
-        if current_branch is not None and current_branch == default_branch:
+        if get_env_var('CI_PIPELINE_SOURCE') == 'schedule':
+            # Do not check scheduled pipelines
+            logger.verbose_print("\ton scheduled pipeline: won't check commits")
+            return commit_hash_head, commit_hash_head
+        elif current_branch is not None and current_branch == default_branch:
+            # If we're on the default branch, just test new commits
             logger.verbose_print(
                 f"\ton default branch '{current_branch}': "
                 'will check new commits'


### PR DESCRIPTION
Applies change as described and explained here: https://github.com/christophebedard/dco-check/issues/79#issuecomment-650154052

If we're on a scheduled GitLab pipeline, set base to head to not check any commits.

Confirmation:

* Push to existing branch: checks commits https://gitlab.com/christophebedard/tracetools_analysis/-/jobs/613105888
* Retry above job: checks commits https://gitlab.com/christophebedard/tracetools_analysis/-/jobs/613111388
* Scheduled pipeline: doesn't check commits https://gitlab.com/christophebedard/tracetools_analysis/-/jobs/613115763

Users of `dco-check` could simply not run it for scheduled pipelines (checking for it as part of the job), but this allows them to just not bother checking.

Closes #79