### PR TITLE
Stop codecov from failing CI jobs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,5 +4,6 @@ coverage:
       default:
         informational: true
     patch:
-      threshold:
+      default:
         threshold: 0%
+        informational: true


### PR DESCRIPTION
A "codecov/patch/threshold" job kept failing on `master`