### PR TITLE
Use version_assertion_command with tag-version-commit action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Check release tag vs dco_check.__version__
-      run: |
-        python3 -c "import dco_check; assert dco_check.__version__ == '${GITHUB_REF/refs\/tags\//}', 'git tag and dco_check version do not match'"
     - name: Generate package
       run: |
         python3 -m pip install --user --upgrade setuptools wheel

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,3 +12,4 @@ jobs:
     - uses: christophebedard/tag-version-commit@v1
       with:
         token: ${{ secrets.TAG_CREATION_TOKEN }}
+        version_assertion_command: 'python3 -c "import dco_check; assert dco_check.__version__ == \"$version\", \"git tag and dco_check version do not match\""'


### PR DESCRIPTION
This moves the version check (git tag vs Python module version) from the publish job to the tag job, using the new `version_assertion_command` input for the tag-version-commit action.