### PR TITLE
Include license file in source packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing
 license = Apache License, Version 2.0
+license_files = LICENSE
 description = Simple DCO check script to be used in any CI.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes #90

Tested locally. `LICENSE` gets included in the source tarball.