### PR TITLE
Fallback to get_common_ancestor_commit_hash for manual GL pipelines

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -621,6 +621,9 @@ class GitlabRetriever(GitRetriever):
                 'will check new commits'
             )
             commit_hash_base = get_env_var('CI_COMMIT_BEFORE_SHA')
+            if commit_hash_base == "0000000000000000000000000000000000000000":
+                # this happens in GitLab when manually launching a pipeline
+                commit_hash_base = get_common_ancestor_commit_hash(default_branch)
             if not commit_hash_base:
                 return None
             return commit_hash_base, commit_hash_head

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -621,7 +621,7 @@ class GitlabRetriever(GitRetriever):
                 'will check new commits'
             )
             commit_hash_base = get_env_var('CI_COMMIT_BEFORE_SHA')
-            if commit_hash_base == "0000000000000000000000000000000000000000":
+            if commit_hash_base == '0000000000000000000000000000000000000000':
                 # this happens in GitLab when manually launching a pipeline
                 commit_hash_base = get_common_ancestor_commit_hash(default_branch)
             if not commit_hash_base:


### PR DESCRIPTION
Workaround/fallback for undocumented GitLab behaviour: if a pipeline is
manually run against any branch (i.e. it is not triggered by a commit or
by a MR or PR), CI_COMMIT_BEFORE_SHA is set to a string of 40 zeros. In
such case, to avoid that commit range check fails with error, we need to
fallback to get_common_ancestor_commit_hash

Solves #92  