### PR TITLE
Fix GitLab pipelines on default branch with no new commits

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -622,7 +622,7 @@ class GitlabRetriever(GitRetriever):
             )
             commit_hash_base = get_env_var('CI_COMMIT_BEFORE_SHA')
             if commit_hash_base == '0000000000000000000000000000000000000000':
-                logger.verbose_print("\tfound no new commits")
+                logger.verbose_print('\tfound no new commits')
                 return commit_hash_head, commit_hash_head
             if not commit_hash_base:
                 return None

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -621,6 +621,9 @@ class GitlabRetriever(GitRetriever):
                 'will check new commits'
             )
             commit_hash_base = get_env_var('CI_COMMIT_BEFORE_SHA')
+            if commit_hash_base == '0000000000000000000000000000000000000000':
+                logger.verbose_print("\tfound no new commits")
+                return commit_hash_head, commit_hash_head
             if not commit_hash_base:
                 return None
             return commit_hash_base, commit_hash_head


### PR DESCRIPTION
Fix #92 

In GitLab, when a pipeline is launched but there are no new commits (eg. when a pipeline is manually launched via GL webUI), `CI_COMMIT_BEFORE_SHA` is set to a string of 40 zeros. This fix expressly handles this case, to avoid internal python errors and to correctly **skip DCO check because it's not needed**.

I added an example in the comment below, with GitLab pipeline logs from a dummy repo

