### PR TITLE
Reset locale when invoking external commands

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -258,10 +258,17 @@ def run(
     """
     output = None
     try:
+        env = os.environ.copy()
+        if 'LANG' in env:
+            del env['LANG']
+        for key in list(env.keys()):
+            if key.startswith('LC_'):
+                del env[key]
         process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env=env,
         )
         output_stdout, _ = process.communicate()
         if process.returncode != 0:


### PR DESCRIPTION
When external commands, like git, are invoked, they can return localized
text. This breaks the logic carefully parsing the output, such as when
get_default_branch_from_remote is invoked on a system with non-English
locale and properly translated git.

Prune LANG and any variables starting with LC_ from the environment,
reverting back to the usual C locale.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>