### PR TITLE
Return boolean value from is_valid_email

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -285,7 +285,7 @@ def is_valid_email(
     :param email: the email address to check
     :return: true if email is valid, false otherwise
     """
-    return re.match(r'^\S+@\S+\.\S+', email)
+    return bool(re.match(r'^\S+@\S+\.\S+', email))
 
 
 def get_head_commit_hash() -> Optional[str]:


### PR DESCRIPTION
The function is documented to return a boolean, but the actual return
type is Optional[Match[str]] - either an None is returned or a Match
object on text strings.

Explicitly convert the result to a boolean.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>