### PR TITLE
Handle missing or corrupted mail in process_commits

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -987,7 +987,10 @@ def process_commits(
         # Extract sign off information
         sign_offs_name_email: List[Tuple[str, str]] = []
         for sign_off in sign_offs:
-            name, email = extract_name_and_email(sign_off)
+            sign_off_result = extract_name_and_email(sign_off)
+            if not sign_off_result:
+                continue
+            name, email = sign_off_result
             logger.verbose_print(f'\t\tfound sign-off: {format_name_and_email(name, email)}')
             if not is_valid_email(email):
                 infractions[commit.hash].append(f'invalid email: {email}')


### PR DESCRIPTION
process_commits calls extract_name_and_email which can return None in
when the given text doesn't look like a name and email pair. Handle this
case by skipping such entries.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>