### PR TITLE
Handle missing commits data in get_commits

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -565,8 +565,10 @@ class GitRetriever(CommitDataRetriever):
     ) -> Optional[List[CommitInfo]]:  # noqa: D102
         ignore_merge_commits = not check_merge_commits
         commits_data = get_commits_data(base, head, ignore_merge_commits=ignore_merge_commits)
-        individual_commits = split_commits_data(commits_data)
         commits = []
+        if commits_data is None:
+            return commits
+        individual_commits = split_commits_data(commits_data)
         for commit_data in individual_commits:
             commit_lines = commit_data.split('\n')
             commit_hash = commit_lines[0]


### PR DESCRIPTION
The function calls get_commits_data which can return None. Handle this
by returning an empty list of commits instead of going into the loop
processing each commit data.

Signed-off-by: Zygmunt Krynicki <me@zygoon.pl>