### PR TITLE
Add --version option

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -175,6 +175,12 @@ def get_parser() -> argparse.ArgumentParser:
             'verbose mode (print out more information) (default: %(default)s)'
         ),
     )
+    parser.add_argument(
+        '--version',
+        action='version',
+        help='show version number and exit',
+        version=f'dco-check version {__version__}',
+    )
     return parser
 
 


### PR DESCRIPTION
Prints the version number and exits, e.g.

    dco-check version 0.0.12

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>