### PR TITLE
Build and push to Docker Hub in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,17 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+  containerize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: christophebedard/dco-check:latest


### PR DESCRIPTION
Based on: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>