### PR TITLE
Build Docker image for arm64 as well

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -37,3 +39,4 @@ jobs:
           context: .
           push: true
           tags: christophebedard/dco-check:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Closes #116

Based on: https://github.com/docker/build-push-action/blob/b1aeb1103e6b3b5648dbd6deaf0559919456ca6b/docs/advanced/multi-platform.md.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>