### PR TITLE
feat: add support for GH's pull_request_target

### DIFF
--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -907,7 +907,7 @@ class GitHubRetriever(CommitDataRetriever):
             return None
         commit_hash_base = None
         commit_hash_head = None
-        if event_name == 'pull_request':
+        if event_name in ('pull_request', 'pull_request_target'):
             # See: https://developer.github.com/v3/activity/events/types/#pullrequestevent
             commit_hash_base = self.event_payload['pull_request']['base']['sha']
             commit_hash_head = self.event_payload['pull_request']['head']['sha']


### PR DESCRIPTION
GitHub defines 2 types of Pull Request events:
- [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)
- [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)

AFAIK, from `dco-check`'s point of view, it does not make any difference, as in both cases the `event_payload` is the same.