### PR TITLE
Generic commit author emails used by bots omitted from checks with a regex pattern match

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Run with `--help` for more information and options, including:
 * default branch
 * default remote
 * list of commit author emails to exclude from checks
+* regular expression pattern to exclude generic emails when matched 
 * quiet mode
 * verbose mode
 * excluding certain author emails (e.g., for bots)

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -39,6 +39,7 @@ ENV_VAR_DEFAULT_BRANCH = 'DCO_CHECK_DEFAULT_BRANCH'
 ENV_VAR_DEFAULT_BRANCH_FROM_REMOTE = 'DCO_CHECK_DEFAULT_BRANCH_FROM_REMOTE'
 ENV_VAR_DEFAULT_REMOTE = 'DCO_CHECK_DEFAULT_REMOTE'
 ENV_VAR_EXCLUDE_EMAILS = 'DCO_CHECK_EXCLUDE_EMAILS'
+ENV_VAR_EXCLUDE_PATTERN = 'DCO_CHECK_EXCLUDE_PATTERN'
 ENV_VAR_QUIET = 'DCO_CHECK_QUIET'
 ENV_VAR_VERBOSE = 'DCO_CHECK_VERBOSE'
 TRAILER_KEY_SIGNED_OFF_BY = 'Signed-off-by:'
@@ -167,6 +168,15 @@ def get_parser() -> argparse.ArgumentParser:
             '(commits with an author email matching one of these emails will be ignored)'
         ),
     )
+    parser.add_argument(
+        '-p', '--exclude-pattern', metavar='REGEX',
+        action=EnvDefaultOption, env_var=ENV_VAR_EXCLUDE_PATTERN,
+        default=None,
+        help=(
+            'exclude regular expresssion matched author emails from checks '
+            '(commits with an author email matching regular expression pattern will be ignored)'
+        ),
+    )
     output_options_group = parser.add_mutually_exclusive_group()
     output_options_group.add_argument(
         '-q', '--quiet',
@@ -214,6 +224,7 @@ class Options:
         self.default_branch_from_remote = parser.get_default('default-branch-from-remote')
         self.default_remote = parser.get_default('r')
         self.exclude_emails = parser.get_default('e')
+        self.exclude_pattern = parser.get_default('p')
         self.quiet = parser.get_default('q')
         self.verbose = parser.get_default('v')
 
@@ -225,6 +236,9 @@ class Options:
         self.default_remote = args.default_remote
         # Split into list and filter out empty elements
         self.exclude_emails = list(filter(None, (args.exclude_emails or '').split(',')))
+        self.exclude_pattern = (
+            None if not args.exclude_pattern else re.compile(args.exclude_pattern)
+        )
         self.quiet = args.quiet
         self.verbose = args.verbose
         # Shouldn't happen with a mutually exclusive group,
@@ -1020,6 +1034,14 @@ def process_commits(
             logger.verbose_print('\t\texcluding commit since author email is in exclude list')
             logger.verbose_print()
             continue
+
+        # Check if the commit should be ignored because of the commit author email pattern
+        if commit.author_email and options.exclude_pattern:
+            if options.exclude_pattern.search(commit.author_email):
+                logger.verbose_print('\t\texcluding commit since author email is matched by')
+                logger.verbose_print('\t\tpattern')
+                logger.verbose_print()
+                continue
 
         # Extract sign-off data
         sign_offs = [

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -36,6 +36,7 @@ class TestLogger(unittest.TestCase):
             default_branch_from_remote=False,
             default_remote='c',
             exclude_emails=None,
+            exclude_pattern=None,
             quiet=False,
             verbose=False,
         )
@@ -60,6 +61,7 @@ class TestLogger(unittest.TestCase):
             default_branch_from_remote=False,
             default_remote='c',
             exclude_emails=None,
+            exclude_pattern=None,
             quiet=False,
             verbose=True,
         )
@@ -76,6 +78,7 @@ class TestLogger(unittest.TestCase):
             default_branch_from_remote=False,
             default_remote='c',
             exclude_emails=None,
+            exclude_pattern=None,
             quiet=True,
             verbose=False,
         )

--- a/test/test_options_args.py
+++ b/test/test_options_args.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+import re
 import sys
 import unittest
 from unittest.mock import patch
@@ -52,6 +53,7 @@ class TestOptionsArgs(unittest.TestCase):
             default_branch_from_remote=False,
             default_remote='c',
             exclude_emails='email@gmail.com,other@gmail.com',
+            exclude_pattern='\\[bot\\]@gmail\\.com',
             quiet=True,
             verbose=False,
         )
@@ -61,11 +63,16 @@ class TestOptionsArgs(unittest.TestCase):
         self.assertEqual(False, options.default_branch_from_remote)
         self.assertEqual('c', options.default_remote)
         self.assertEqual(['email@gmail.com', 'other@gmail.com'], options.exclude_emails)
+        self.assertEqual(re.compile('\\[bot\\]@gmail\\.com'), options.exclude_pattern)
         self.assertEqual(True, options.quiet)
         self.assertEqual(False, options.verbose)
 
         self.assertDictEqual(
-            {**vars(ns), 'exclude_emails': ['email@gmail.com', 'other@gmail.com']},
+            {
+                **vars(ns),
+                'exclude_emails': ['email@gmail.com', 'other@gmail.com'],
+                'exclude_pattern': re.compile('\\[bot\\]@gmail\\.com')
+            },
             options.get_options(),
         )
 
@@ -77,6 +84,7 @@ class TestOptionsArgs(unittest.TestCase):
             'DCO_CHECK_DEFAULT_BRANCH_FROM_REMOTE',
             'DCO_CHECK_DEFAULT_REMOTE',
             'DCO_CHECK_EXCLUDE_EMAILS',
+            'DCO_CHECK_EXCLUDE_PATTERN',
             'DCO_CHECK_QUIET',
             'DCO_CHECK_VERBOSE',
         ]
@@ -91,6 +99,7 @@ class TestOptionsArgs(unittest.TestCase):
         os.environ['DCO_CHECK_DEFAULT_BRANCH'] = 'adefaultbranch'
         os.environ['DCO_CHECK_DEFAULT_REMOTE'] = 'adefaultremote'
         os.environ['DCO_CHECK_EXCLUDE_EMAILS'] = 'email@gmail.com,other@gmail.com'
+        os.environ['DCO_CHECK_EXCLUDE_PATTERN'] = '\\[bot\\]@gmail\\.com'
         os.environ['DCO_CHECK_QUIET'] = 'True'
         # os.environ['DCO_CHECK_VERBOSE'] = 'False'
         test_argv = ['dco_check/dco_check.py']
@@ -102,6 +111,7 @@ class TestOptionsArgs(unittest.TestCase):
             self.assertEqual('adefaultbranch', options.default_branch)
             self.assertEqual('adefaultremote', options.default_remote)
             self.assertEqual(['email@gmail.com', 'other@gmail.com'], options.exclude_emails)
+            self.assertEqual(re.compile('\\[bot\\]@gmail\\.com'), options.exclude_pattern)
             self.assertEqual(True, options.quiet)
             self.assertEqual(False, options.verbose)
 
@@ -111,6 +121,7 @@ class TestOptionsArgs(unittest.TestCase):
         os.environ['DCO_CHECK_DEFAULT_BRANCH'] = 'adefaultbranch'
         os.environ['DCO_CHECK_DEFAULT_REMOTE'] = 'adefaultremote'
         os.environ['DCO_CHECK_EXCLUDE_EMAILS'] = 'email@gmail.com,other@gmail.com'
+        os.environ['DCO_CHECK_EXCLUDE_PATTERN'] = '\\[bot\\]@gmail\\.com'
         os.environ['DCO_CHECK_QUIET'] = 'True'
         # os.environ['DCO_CHECK_VERBOSE'] = 'False'
         test_argv = [

--- a/test/test_processing.py
+++ b/test/test_processing.py
@@ -199,6 +199,7 @@ class TestProcessing(unittest.TestCase):
             default_branch_from_remote=False,
             default_remote='c',
             exclude_emails='laa@laa.laa,tinky@winky.com',
+            exclude_pattern='gen\\[bot\\]@gmail\\.com',
             quiet=False,
             verbose=False,
         )
@@ -246,6 +247,19 @@ class TestProcessing(unittest.TestCase):
                 ['Signed-off-by: Laa-Laa <laa@laa.laa>'],
                 'Laa-Laa',
                 'laa@laa.laa',
+                False,
+            ),
+        ]
+        self.assertEqual(0, len(process_commits(commits, False)))
+        
+        # Signed-off but author email is matched with exclude pattern
+        commits = [
+            CommitInfo(
+                'adc',
+                'This is a commit title',
+                ['Signed-off-by: genericbot <[bot]@gmail.com>'],
+                'generic_bot',
+                '277373_gen[bot]@gmail.com',
                 False,
             ),
         ]


### PR DESCRIPTION
- exclude pattern argument added similar to exclude emails
- pattern checked against commit author email for omitting checks
- unit tests updated and pattern check included in email exclusion test
- README.md updated

fixes #123