### PR TITLE
Update actions & Python versions in CI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,4 @@ workflows:
       - check-DCO:
           matrix:
             parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.10"]

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Check DCO

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Generate package
@@ -26,7 +26,7 @@ jobs:
   containerize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: christophebedard/tag-version-commit@v1
       with:
         token: ${{ secrets.TAG_CREATION_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install test dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ branches:
 
 language: python
 python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
+  - "3.10"
 dist: bionic
 install:
   - pip install -U pytest pytest-cov pytest-repeat

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Check DCO

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,7 @@ branches:
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python36-x64"
-    - PYTHON: "C:\\Python37-x64"
-    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python310-x64"
 install:
   - "%PYTHON%\\python.exe -m pip install -U pytest pytest-cov pytest-repeat"
   - "%PYTHON%\\python.exe -m pip install -U flake8 flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-import-order flake8-quotes pep8-naming pylint"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,12 +6,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
+      Python310:
+        python.version: '3.10'
   steps:
   - task: UsePythonVersion@0
     inputs:
@@ -39,12 +35,8 @@ jobs:
     vmImage: 'windows-latest'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
+      Python310:
+        python.version: '3.10'
   steps:
   - task: UsePythonVersion@0
     inputs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,9 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing
 license = Apache License, Version 2.0

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [dco-check]
 Depends3: python3
-Suite: xenial bionic focal stretch buster
+Suite: xenial bionic focal jammy stretch buster
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
* Bump `actions/*` versions
* Update Python version matrices to active Python versions: https://www.python.org/downloads/ (remove 3.6; add 3.9, 3.10, and 3.11)
* Only test using Python 3.10 for non-GitHub CI

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>