### PR TITLE
fix : added merge group support + action.yml for github action

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check DCO
     steps:
       - name: Run dco-check
-        uses: EthanPERRUZZA/dco-check@master
+        uses: christophebedard/dco-check@master
         with:
             python-version: ${{ matrix.python-version }}
             args: '--verbose'

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -7,19 +7,17 @@ on:
       - master
 
 jobs:
-  check:
+  check_dco:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    name: Check DCO
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Check DCO
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        python3 dco_check/dco_check.py --verbose
+      - name: Run dco-check
+        uses: christophebedard/dco-check@0.5.0
+        with:
+            python-version: ${{ matrix.python-version }}
+            args: '--verbose'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check DCO
     steps:
       - name: Run dco-check
-        uses: christophebedard/dco-check@0.5.0
+        uses: EthanPERRUZZA/dco-check@master
         with:
             python-version: ${{ matrix.python-version }}
             args: '--verbose'

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -118,9 +118,14 @@ jobs:
     steps:
       - name: Run dco-check
         uses: christophebedard/dco-check@0.5.0
+        with:
+            python-version: '3.12'
+            args: '--verbose'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+Please note that the `with:` property is optional, the default python version is 3.12 and no additional arguments are passed by default.
 
 ### GitLab
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check DCO
     steps:
-      - name: DCO Compliance Check
+      - name: Run dco-check
         uses: christophebedard/dco-check@0.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -112,20 +112,14 @@ on:
     branches:
       - master
 jobs:
-  check:
+  check_dco:
     runs-on: ubuntu-latest
+    name: Check DCO
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
-    - name: Check DCO
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        pip3 install -U dco-check
-        dco-check
+      - name: DCO Compliance Check
+        uses: christophebedard/dco-check@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### GitLab

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Please note that the `with:` property is optional, the default python version is 3.12 and no additional arguments are passed by default.
+Please note that the `with:` property is optional, the default Python version is 3.12 and no additional arguments are passed by default.
 
 ### GitLab
 

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,14 @@
 # action.yml
-name: 'Check DCO Signoff'
-description: 'A reusable action that checks if all commit has a DCO signoff'
+name: 'DCO check'
+description: 'A reusable action that checks that all commits for a proposed change are signed off'
 runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
 
-    - name: Run Python script
+    - name: Check DCO
       run: python ${{ github.action_path }}/dco_check.py
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,14 @@
+# action.yml
+name: 'Check DCO Signoff'
+description: 'A reusable action that checks if all commit has a DCO signoff'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+
+    - name: Run Python script
+      run: python ${{ github.action_path }}/dco_check.py
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Check DCO
-      run: python ${{ github.action_path }}/dco_check.py ${{ inputs.args }}
+      run: python ${{ github.action_path }}/dco_check/dco_check.py ${{ inputs.args }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,25 @@
 # action.yml
 name: 'DCO check'
 description: 'A reusable action that checks that all commits for a proposed change are signed off'
+
+inputs:
+  args:
+    description: "Arguments to be added the dco_check.py execution line."
+    required: false
+    default: ''
+  python-version:
+    description: "The version of python to be used."
+    required: false
+    default: '3.12'
+
 runs:
   using: "composite"
   steps:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: ${{ inputs.python-version }}
 
     - name: Check DCO
-      run: python ${{ github.action_path }}/dco_check.py
+      run: python ${{ github.action_path }}/dco_check.py ${{ inputs.args }}
       shell: bash

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -931,14 +931,14 @@ class GitHubRetriever(CommitDataRetriever):
                 f"\ton pull request branch '{commit_branch_head}': "
                 f"will check commits off of base branch '{commit_branch_base}'"
             )
-        elif event_name in 'merge_group':
+        elif event_name == 'merge_group':
             # See: https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group
             commit_hash_base = self.event_payload['merge_group']['base_sha']
             commit_hash_head = self.event_payload['merge_group']['head_sha']
             commit_branch_base = self.event_payload['merge_group']['base_ref']
             commit_branch_head = self.event_payload['merge_group']['head_ref']
             logger.verbose_print(
-                f"\ton merge request branch '{commit_branch_head}': "
+                f"\ton merge group branch '{commit_branch_head}': "
                 f"will check commits off of base branch '{commit_branch_base}'"
             )
         elif event_name == 'push':

--- a/dco_check/dco_check.py
+++ b/dco_check/dco_check.py
@@ -931,6 +931,16 @@ class GitHubRetriever(CommitDataRetriever):
                 f"\ton pull request branch '{commit_branch_head}': "
                 f"will check commits off of base branch '{commit_branch_base}'"
             )
+        elif event_name in 'merge_group':
+            # See: https://docs.github.com/en/webhooks/webhook-events-and-payloads#merge_group
+            commit_hash_base = self.event_payload['merge_group']['base_sha']
+            commit_hash_head = self.event_payload['merge_group']['head_sha']
+            commit_branch_base = self.event_payload['merge_group']['base_ref']
+            commit_branch_head = self.event_payload['merge_group']['head_ref']
+            logger.verbose_print(
+                f"\ton merge request branch '{commit_branch_head}': "
+                f"will check commits off of base branch '{commit_branch_base}'"
+            )
         elif event_name == 'push':
             # See: https://developer.github.com/v3/activity/events/types/#pushevent
             created = self.event_payload['created']

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,12 +15,11 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing
 license = Apache License, Version 2.0


### PR DESCRIPTION
Hey there!

In some of our project repositories, we use the `merge-group` feature, and when trying to use your script, we noticed it wasn't working as expected. To address this, we wrote some additional code to ensure compatibility and would love to contribute it back.

While working on this, we also added an action.yml file for easier integration with GitHub Actions and to simplify the workflow syntax. Let us know if you have any feedback or suggestions!

Thanks!